### PR TITLE
Adding script to enable debugging of overlays via GDB

### DIFF
--- a/setoverlay.gdb
+++ b/setoverlay.gdb
@@ -1,0 +1,7 @@
+connect --reset-to-mode-pins
+p __overlay_address
+disconnect
+connect --xscope
+load
+set variable __overlay_address=$1
+c


### PR DESCRIPTION
I'm not sure 

```
connect --reset-to-mode-pins
```

is the correct way to reset the device but seems to work.
